### PR TITLE
Fix gemspec dependencies test-kitchen logic

### DIFF
--- a/kitchen-vro.gemspec
+++ b/kitchen-vro.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "test-kitchen", "~> 1.4", "< 4"
+  spec.add_dependency "test-kitchen", ">= 1.4", "< 4"
   spec.add_dependency "vcoworkflows", "~> 0.2"
 end


### PR DESCRIPTION
# Description

This commit fixes gemspec version dependencies for test-kitchen.

## Issues Resolved

kitchen-vro stopped working with latest chef-workstation package, because kitchen-vro had wrong dependency versions.
Error without fix:

E, [2024-02-05T15:29:55.975080 #4110] ERROR -- Kitchen: Message: Unable to activate kitchen-vro-1.0.0, because test-kitchen-3.3.1 conflicts with test-kitchen (~> 1.4, >= 1.4.1) 
