### PR TITLE
[fix] Bump version to 1.2.0

### DIFF
--- a/lib/kitchen/driver/version.rb
+++ b/lib/kitchen/driver/version.rb
@@ -18,6 +18,6 @@
 
 module Kitchen
   module Driver
-    VRO_VERSION = "1.1.0".freeze
+    VRO_VERSION = "1.2.0".freeze
   end
 end


### PR DESCRIPTION
# Description

Recently a new version 1.2.0 was realesed but kitchen/driver/version.rb is not reflecting it.

## Issues Resolved

The CI action to publish to rubygems shows version 1.1.0 while it should be 1.2.0.

## Type of Change
  Obvious fix.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [X] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)

