### PR TITLE
Remove chefstyle and add the gem version badge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,9 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'bundler'
   gem 'rake'
   gem 'rspec', '~> 3.2'
   gem 'webmock',   '~> 3.0'
-end
-
-group :chefstyle do
-  gem 'chefstyle', '~> 2.2', '>= 2.2.3'
 end
 
 group :cookstyle do

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # kitchen-vro
 
+[![Gem Version](https://badge.fury.io/rb/kitchen-vro.svg)](https://badge.fury.io/rb/kitchen-vro)
+
 A driver to allow Test Kitchen to consume VMware resources provisioned by
 way of vRealize Orchestrator workflows.
 


### PR DESCRIPTION
Follow-up cleanup to the Ruby 3.1 / CI modernization PR.

- Remove the `chefstyle` bundler group. chefstyle pins an old rubocop, which resolves cookstyle down to 7.x, where `cookstyle --chefstyle` is not a valid option — so the lint job would fail. Cookstyle supersedes chefstyle.
- Add the gem version badge to the README, which was missing one.
- Drop the `bundler` dev dependency; bundler ships with Ruby and pinning it only constrains resolution.

Config/docs only; no functional changes.