### PR TITLE
Let cookstyle decide which files to lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,6 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.1
-  Include:
-    - "**/*.rb"
   Exclude:
     - "vendor/**/*"
     - "spec/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
 group :test do
-  gem 'rake'
-  gem 'rspec', '~> 3.2'
-  gem 'webmock',   '~> 3.0'
+  gem "rake"
+  gem "rspec", "~> 3.2"
+  gem "webmock",   "~> 3.0"
 end
 
 group :cookstyle do

--- a/kitchen-vro.gemspec
+++ b/kitchen-vro.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "kitchen/driver/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "kitchen-vro"
+  spec.name = "kitchen-vro"
   spec.required_ruby_version = ">= 3.1"
   spec.version       = Kitchen::Driver::VRO_VERSION
   spec.authors       = ["Test Kitchen Team"]
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = []
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_dependency "test-kitchen", ">= 1.4", "< 5"


### PR DESCRIPTION
`AllCops/Include` pinned the file list to `**/*.rb`, which quietly excluded the **gemspec, Gemfile and Rakefile** — cookstyle reported success while never looking at them.

Removing the `Include` list restores cookstyle's own defaults, which already cover those files. The offenses that surfaced are autocorrected here.

Verified after the change: `cookstyle --chefstyle` is clean, the gemspec still loads, and the Gemfile/Rakefile still parse.
