### PR TITLE
Docs: rewrite README for new users and split contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to kitchen-vro
+
+We'd love to hear from you if this driver doesn't perform the way you expect. Bug reports, feature requests, and pull requests are all welcome.
+
+## Reporting issues
+
+Report bugs and request features on the [issue tracker](https://github.com/test-kitchen/kitchen-vro/issues). For bugs, please include:
+
+- the version of kitchen-vro and Test Kitchen you are using
+- your vRO version
+- your `kitchen.yml` with credentials and internal hostnames removed
+- the input and output parameters of the workflows involved
+- the output of the failing command, ideally with `-l debug`
+
+## Development setup
+
+Clone the repository and install the dependencies:
+
+```sh
+git clone https://github.com/test-kitchen/kitchen-vro.git
+cd kitchen-vro
+bundle install
+```
+
+## Running the tests
+
+Run the unit tests and the style check together:
+
+```sh
+bundle exec rake
+```
+
+Run them individually:
+
+```sh
+bundle exec rake test    # RSpec unit tests
+bundle exec rake style   # Cookstyle / RuboCop
+```
+
+To run a single spec file:
+
+```sh
+bundle exec rspec spec/kitchen/driver/vro_spec.rb
+```
+
+Many style offenses can be corrected automatically:
+
+```sh
+bundle exec cookstyle -a
+```
+
+The unit tests stub the vRO client, so they do not contact an appliance and do
+not require credentials.
+
+### Manual testing against vRO
+
+Changes that touch workflow execution or parameter handling should also be
+exercised against a real appliance, since the stubbed tests cannot catch
+API-level regressions.
+
+You will need a create workflow and a destroy workflow meeting the requirements
+in the README's Workflow design section. Set the password in the environment
+rather than in `kitchen.yml`, and confirm after `kitchen destroy` that the
+destroy workflow actually removed the machine — a create that fails partway
+through can leave one behind.
+
+## Submitting changes
+
+1. Fork the repository.
+2. Create a feature branch off `main`.
+3. Make your change, adding or updating tests to cover it.
+4. Make sure `bundle exec rake` passes.
+5. Push the branch to your fork and open a pull request.
+
+Please keep pull requests focused on a single change — it makes review much
+faster. Update the documentation in `README.md` when you add or change a
+configuration option, and the Workflow design section when you change what the
+driver expects of a workflow.
+
+## Release process
+
+Releases are handled by the maintainers.
+
+1. Update `lib/kitchen/driver/version.rb` with the new version.
+2. Update `CHANGELOG.md`.
+3. Merge to `main`; the [publish workflow](.github/workflows/publish.yaml) builds
+   the gem and pushes it to RubyGems.

--- a/README.md
+++ b/README.md
@@ -2,79 +2,145 @@
 
 [![Gem Version](https://badge.fury.io/rb/kitchen-vro.svg)](https://badge.fury.io/rb/kitchen-vro)
 
-A driver to allow Test Kitchen to consume VMware resources provisioned by
-way of vRealize Orchestrator workflows.
+A [Test Kitchen](https://kitchen.ci/) driver that provisions and destroys VMware resources by running [vRealize Orchestrator](https://www.vmware.com/products/vrealize-orchestrator.html) (vRO) workflows, so you can test your cookbooks and infrastructure code against machines built by your own workflows.
 
-vRO allows you to create any workflow you can imagine, but our plugin needs
-to make some assumptions about the workflows you design in order to properly
-provision and destroy resources.  Therefore, please pay special attention to
-the **Workflow Design** section below and ensure your workflows adhere to
-these design requirements.
+Because a vRO workflow can do anything, this driver has to make some assumptions about the ones it calls. Read [Workflow design](#workflow-design) before you start — your create and destroy workflows must expose specific parameters for the driver to work.
+
+> This documentation uses [Cinc Workstation](https://cinc.sh/) and the `cinc` commands throughout. Everything here works identically with Chef Workstation — see [Using with Chef](#using-with-chef).
+
+## Requirements
+
+- Ruby 3.1 or later (already satisfied if you use Cinc Workstation)
+- Access to a vRealize Orchestrator appliance
+- A **create** workflow and a **destroy** workflow meeting the requirements in [Workflow design](#workflow-design)
+- Permission to execute those workflows
 
 ## Installation
 
-Add this line to your application's Gemfile:
+This driver ships as part of [Cinc Workstation](https://cinc.sh/start/workstation/). If you have Cinc Workstation installed, there is nothing else to install.
 
-```ruby
-gem 'kitchen-vro'
-```
+To install it into a standalone Ruby:
 
-And then execute:
-
-```shell
-bundle
-```
-
-Or install it yourself as:
-
-```shell
+```sh
 gem install kitchen-vro
 ```
 
-Or even better, install it via ChefDK:
+Or with Bundler, add it to your `Gemfile`:
 
-```shell
-chef gem install kitchen-vro
+```ruby
+gem "kitchen-vro"
 ```
 
-## Usage
+...then run `bundle install`.
 
-After installing the gem as described above, edit your .kitchen.yml file to set the driver to 'vro' and supply your login credentials:
+## Quick Start
 
 ```yaml
+---
 driver:
   name: vro
   vro_username: user@domain.com
-  vro_password: MyS33kretPassword
+  vro_password: <%= ENV['VRO_PASSWORD'] %>
   vro_base_url: https://vra.corp.local:8281
+  create_workflow_name: Create TK Server
+  destroy_workflow_name: Destroy TK Server
+
+provisioner:
+  name: cinc_infra
+
+verifier:
+  name: cinc_auditor
+
+platforms:
+  - name: centos-9
+
+suites:
+  - name: default
+    run_list:
+      - recipe[my_cookbook::default]
 ```
 
-Additionally, the following parameters are required, either globally or per-platform:
+Then run the full test cycle:
 
-* **create_workflow_name**: The name of the vRO workflow to execute to create a server.
-* **destroy_workflow_name**: The name of the vRO workflow to execute to destroy a server.
+```sh
+cinc kitchen test
+```
 
-There are a number of optional parameters you can configure as well:
+Or step through it:
 
-* **create_workflow_id**: If your create workflow name is not unique within vRO, you can use
-   this parameter to specify the workflow unique ID.
-* **destroy_workflow_id**: If your destroy workflow name is not unique within vRO, you can use
-   this parameter to specify the workflow unique ID.
-* **create_workflow_parameters**: A hash of key-value pairs of parameters to pass to your
-   create workflow.
-* **destroy_workflow_parameters**: A hash of key-value pairs of parameters to pass to your
-   destroy workflow.
-* **request_timeout**: Number of seconds to wait for a vRO workflow to execute.  Default: 300
-* **vro_disable_ssl_verify**: Disable SSL validation.  Default: false
+```sh
+cinc kitchen create    # run the create workflow and wait for it
+cinc kitchen converge  # apply your cookbook
+cinc kitchen verify    # run your tests
+cinc kitchen destroy   # run the destroy workflow
+```
 
-An example `.kitchen.yml` that uses a combination of global and per-platform
-settings might look like this:
+Keep the password out of `kitchen.yml` by reading it from the environment, as above.
+
+## Configuration
+
+All options below are set under the `driver:` key in `kitchen.yml`, or per platform under `platforms[].driver:`.
+
+### Required
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `vro_base_url` | *none* | Base URL of the vRO appliance, e.g. `https://vra.corp.local:8281`. Required. |
+| `vro_username` | *none* | Username to authenticate with, e.g. `user@domain.com`. Required. |
+| `vro_password` | *none* | Password to authenticate with. Required. |
+| `create_workflow_name` | *none* | Name of the vRO workflow that creates a server. Required. |
+| `destroy_workflow_name` | *none* | Name of the vRO workflow that destroys a server. Required. |
+
+### Workflow selection and parameters
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `create_workflow_id` | `nil` | Unique ID of the create workflow. Use this when the workflow name is not unique within vRO. |
+| `destroy_workflow_id` | `nil` | Unique ID of the destroy workflow. Use this when the workflow name is not unique within vRO. |
+| `create_workflow_parameters` | `{}` | Hash of key/value parameters passed to the create workflow. |
+| `destroy_workflow_parameters` | `{}` | Hash of key/value parameters passed to the destroy workflow. |
+
+### Connection
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `request_timeout` | `300` | Seconds to wait for a workflow to finish executing. |
+| `vro_disable_ssl_verify` | `false` | Skip TLS certificate validation. Only use this against a lab appliance with a self-signed certificate. |
+
+## Workflow design
+
+There is no limit to what your vRO workflows can do, but they must meet the
+following requirements for the driver to drive them.
+
+### Create workflow
+
+- Must have an output parameter called **`ip_address`**, which Test Kitchen
+  connects to in order to bootstrap and test the node.
+- Must have an output parameter called **`server_id`**, a unique ID for the
+  server that was created. The driver passes this to the destroy workflow later.
+- Must end with a raised exception if creation did not succeed. The workflow
+  status must not be `completed` when it has failed, or the driver will treat a
+  failed build as a success.
+
+### Destroy workflow
+
+- Must have an input parameter called **`server_id`**, which the driver
+  populates with the value returned by the create workflow.
+- Must end with a raised exception if destruction did not succeed. The workflow
+  status must not be `completed` when it has failed.
+
+## Examples
+
+### Per-platform workflow parameters
+
+Global settings live under `driver:`, and the parameters that differ per
+operating system live under each platform:
 
 ```yaml
 driver:
   name: vro
   vro_username: user@domain.com
-  vro_password: MyS33kretPassword
+  vro_password: <%= ENV['VRO_PASSWORD'] %>
   vro_base_url: https://vra.corp.local:8281
   create_workflow_name: Create TK Server
   destroy_workflow_name: Destroy TK Server
@@ -94,55 +160,98 @@ platforms:
         memory: 4096
 ```
 
-## Workflow Design
+### Workflow names that are not unique
 
-There are no limits as to what you can do with your vRO workflows!  However,
-they must meet the following requirements.
-
-### Create Workflow
-
-* Must contain an output parameter called `ip_address` that Test Kitchen can
-   connect to in order to bootstrap and test your node.
-* Must contain an output parameter called `server_id` that is a unique ID of
-   the server created.  Test Kitchen will provide this value to the Destroy
-   Workflow in order to request the destruction of the server once testing is
-   complete.
-* Must end the workflow with a raised exception if the creation did not
-   succeed.  The workflow status must not be 'completed.'
-
-### Destroy Workflow
-
-* Must contain an input parameter called `server_id` that Test Kitchen will
-   populate with the unique ID returned from the Create Workflow output.
-* Must end the workflow with a raised exception if the creation did not
-     succeed.  The workflow status must not be 'completed.'
-
-## License and Authors
-
-Author:: Chef Partner Engineering (<partnereng@chef.io>)
-
-Copyright:: Copyright (c) 2015 Chef Software, Inc.
-
-License:: Apache License, Version 2.0
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-this file except in compliance with the License. You may obtain a copy of the License at
-
-```text
-http://www.apache.org/licenses/LICENSE-2.0
+```yaml
+driver:
+  name: vro
+  vro_base_url: https://vra.corp.local:8281
+  vro_username: user@domain.com
+  vro_password: <%= ENV['VRO_PASSWORD'] %>
+  create_workflow_name: Create TK Server
+  create_workflow_id: 9f4d4a7e-1234-4b8b-9c2f-77b6c9f0e111
+  destroy_workflow_name: Destroy TK Server
+  destroy_workflow_id: 3a1b2c3d-5678-4e9f-8a1b-22c4d6e8f0a1
 ```
 
-Unless required by applicable law or agreed to in writing, software distributed under the
-License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-either express or implied. See the License for the specific language governing permissions
-and limitations under the License.
+### Passing parameters to the destroy workflow
+
+```yaml
+driver:
+  name: vro
+  vro_base_url: https://vra.corp.local:8281
+  vro_username: user@domain.com
+  vro_password: <%= ENV['VRO_PASSWORD'] %>
+  create_workflow_name: Create TK Server
+  destroy_workflow_name: Destroy TK Server
+  destroy_workflow_parameters:
+    force: true
+    reason: test-kitchen cleanup
+```
+
+### Slow workflows
+
+```yaml
+driver:
+  name: vro
+  vro_base_url: https://vra.corp.local:8281
+  vro_username: user@domain.com
+  vro_password: <%= ENV['VRO_PASSWORD'] %>
+  create_workflow_name: Create TK Server
+  destroy_workflow_name: Destroy TK Server
+  request_timeout: 1800
+```
+
+### Lab appliance with a self-signed certificate
+
+```yaml
+driver:
+  name: vro
+  vro_base_url: https://vro.lab.local:8281
+  vro_username: user@lab.local
+  vro_password: <%= ENV['VRO_PASSWORD'] %>
+  create_workflow_name: Create TK Server
+  destroy_workflow_name: Destroy TK Server
+  vro_disable_ssl_verify: true
+```
+
+## Troubleshooting
+
+**Test Kitchen cannot connect after a successful create.** Check that the create
+workflow really does return an `ip_address` output parameter, and that the
+address is reachable from where you are running Test Kitchen.
+
+**A failed build is reported as successful.** The workflow finished with status
+`completed` despite failing. Raise an exception in the workflow on failure, as
+described in [Workflow design](#workflow-design).
+
+**`kitchen destroy` does nothing, or destroys the wrong machine.** The destroy
+workflow must take a `server_id` input parameter, and the create workflow must
+return a matching `server_id` output.
+
+**The workflow times out.** Increase `request_timeout`; the default is 300
+seconds, which is short for a full VM build.
+
+## Using with Chef
+
+This driver is not tied to Cinc. The examples above use Cinc Workstation and the `cinc_infra` provisioner, but the driver works exactly the same with [Chef Workstation](https://www.chef.io/downloads/tools/workstation) — run `kitchen` instead of `cinc kitchen`, and use `chef_infra` instead of `cinc_infra`:
+
+```yaml
+provisioner:
+  name: chef_infra
+
+verifier:
+  name: inspec
+```
+
+No driver configuration changes are needed.
 
 ## Contributing
 
-We'd love to hear from you if this doesn't perform in the manner you expect. Please log a GitHub issue, or even better, submit a Pull Request with a fix!
+We'd love to hear from you if this doesn't perform the way you expect. Bug reports and pull requests are welcome on [GitHub](https://github.com/test-kitchen/kitchen-vro). See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, how to run the tests, and the release process.
 
-1. Fork it ( <https://github.com/chef-partners/kitchen-vro/fork> )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
+## License and Authors
+
+Author: Chef Partner Engineering (<partnereng@chef.io>)
+
+Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## What

Rewrites `README.md` around a new user's path and moves contributor-only material into a new `CONTRIBUTING.md`.

## Why

This README was in better shape than most — it did document the options — but as a bulleted list that mixed required and optional settings, gave defaults only in prose, and had no quick start. Half the file was inlined Apache license text.

## README

- Requirements, installation (Cinc Workstation first), and a working quick start
- Full configuration reference as tables with real defaults, split into required / workflow selection / connection
- **Workflow design kept in the README** — it's user-facing and you can't use this driver without it. Tightened, with the required parameter names called out and an explanation of *why* a workflow must raise on failure (otherwise a failed build is reported as a successful one)
- Examples: per-platform parameters, non-unique workflow names, destroy parameters, slow workflows, self-signed certificates
- Troubleshooting, derived from the workflow contract: missing `ip_address` output, failed build reported as `completed`, destroy unable to match `server_id`, and the 300s default timeout being short for a real VM build
- A "Using with Chef" section noting the driver is not Cinc-specific

All 11 `default_config`/`required_config` keys are documented.

Also replaces the ChefDK install instructions (superseded by Workstation), updates `.kitchen.yml` to `kitchen.yml`, moves passwords out of the YAML examples and into `ENV`, drops the inlined license text for a link to `LICENSE`, and repoints the fork link from `chef-partners` to `test-kitchen`.

## CONTRIBUTING.md

New file, absorbing the README's Contributing section: issue reporting (including asking for the workflows' input/output parameters, which is usually the root cause), dev setup, `bundle exec rake test`/`style`, and the release process.

## Unrelated nit spotted

`kitchen-vro.gemspec` has `spec.homepage = "https://https://github.com/test-kitchen/kitchen-vro"` — a doubled scheme. Left alone since this is a docs-only PR; happy to fix separately.

Docs only — no code changes.