### PR TITLE
chore: backfill missing changelog history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,31 @@
 # VRO Changelog
 
-## [1.2.3](https://github.com/test-kitchen/kitchen-vro/compare/v1.2.2...v1.2.3) (2026-01-22)
+## Unreleased
 
+* chore(deps): update googleapis/release-please-action action to v5 ([#31](https://github.com/test-kitchen/kitchen-vro/pull/31)) ([309dc1d](https://github.com/test-kitchen/kitchen-vro/commit/309dc1d))
+* chore(deps): update actions/checkout action to v7 ([#32](https://github.com/test-kitchen/kitchen-vro/pull/32)) ([df90c2f](https://github.com/test-kitchen/kitchen-vro/commit/df90c2f))
+* Require Ruby 3.1+ and modernize CI ([#33](https://github.com/test-kitchen/kitchen-vro/pull/33)) ([ba13a07](https://github.com/test-kitchen/kitchen-vro/commit/ba13a07))
+* Remove chefstyle and add the gem version badge ([#34](https://github.com/test-kitchen/kitchen-vro/pull/34)) ([88348d7](https://github.com/test-kitchen/kitchen-vro/commit/88348d7))
+* Let cookstyle decide which files to lint ([#35](https://github.com/test-kitchen/kitchen-vro/pull/35)) ([c252779](https://github.com/test-kitchen/kitchen-vro/commit/c252779))
+* Docs: rewrite README for new users and split contributor docs ([#36](https://github.com/test-kitchen/kitchen-vro/pull/36)) ([c32f1a3](https://github.com/test-kitchen/kitchen-vro/commit/c32f1a3))
+
+## [1.2.3](https://github.com/test-kitchen/kitchen-vro/compare/v1.2.2...v1.2.3) (2026-01-22)
 
 ### Bug Fixes
 
 * bump tk dep to allow tk 4 ([#29](https://github.com/test-kitchen/kitchen-vro/issues/29)) ([2a89105](https://github.com/test-kitchen/kitchen-vro/commit/2a89105a15a65c974d4f9793950c8c6ceab963c1))
 
-## [1.2.2](https://github.com/test-kitchen/kitchen-vro/compare/v1.2.1...v1.2.2) (2024-06-19)
+### Other Changes
 
+* chore(deps): update actions/checkout action to v6 ([#28](https://github.com/test-kitchen/kitchen-vro/pull/28)) ([008fa0e](https://github.com/test-kitchen/kitchen-vro/commit/008fa0e))
+
+## [1.2.2](https://github.com/test-kitchen/kitchen-vro/compare/v1.2.1...v1.2.2) (2024-06-19)
 
 ### Bug Fixes
 
 * release please deprecation ([#25](https://github.com/test-kitchen/kitchen-vro/issues/25)) ([2fc4da5](https://github.com/test-kitchen/kitchen-vro/commit/2fc4da56e566b52d631f5ccbf661131f14609c13))
 
 ## [1.2.1](https://github.com/test-kitchen/kitchen-vro/compare/v1.2.1...v1.2.1) (2024-06-09)
-
 
 ### Features
 
@@ -28,23 +38,22 @@
 * bump verion to 1.2.1 ([#22](https://github.com/test-kitchen/kitchen-vro/issues/22)) ([498f90f](https://github.com/test-kitchen/kitchen-vro/commit/498f90ff6618b643795d29adbc120c5b4dc4fb26))
 * release 1.2.0 ([#18](https://github.com/test-kitchen/kitchen-vro/issues/18)) ([3356c6f](https://github.com/test-kitchen/kitchen-vro/commit/3356c6f22b91c02283ec4d31a7ac6179ecd27876))
 
-## [1.2.0](https://github.com/test-kitchen/kitchen-vro/compare/v1.2.0...v1.2.0) (2024-04-10)
-
-
-### Miscellaneous Chores
-
-* release 1.2.0 ([#18](https://github.com/test-kitchen/kitchen-vro/issues/18)) ([3356c6f](https://github.com/test-kitchen/kitchen-vro/commit/3356c6f22b91c02283ec4d31a7ac6179ecd27876))
-
-## [1.2.0](https://github.com/test-kitchen/kitchen-vro/compare/v1.1.0...v1.2.0) (2024-02-28)
-
-
-### Features
-
-* update workflows ([#15](https://github.com/test-kitchen/kitchen-vro/issues/15)) ([277a0ab](https://github.com/test-kitchen/kitchen-vro/commit/277a0aba28a50b99272962973a589898dd144fad))
-
-## [1.1.0](https://github.com/test-kitchen/kitchen-vro/compare/v1.0.0...v1.1.0) (2023-11-27)
-
-
-### Features
+### Other Changes
 
 * Workflows ([#10](https://github.com/test-kitchen/kitchen-vro/issues/10)) ([3f51d13](https://github.com/test-kitchen/kitchen-vro/commit/3f51d13a5afc683f6f3c1c4816f37ec0c65c4d63))
+* adding to travis ([e197f8b](https://github.com/test-kitchen/kitchen-vro/commit/e197f8b))
+* disabling ruby 2.0 in travis due to vcoworkflows bug ([7e40c92](https://github.com/test-kitchen/kitchen-vro/commit/7e40c92))
+* adding slack notifications to travis ([d158e38](https://github.com/test-kitchen/kitchen-vro/commit/d158e38))
+* disabling rvm 2.0.0 again ([6027c75](https://github.com/test-kitchen/kitchen-vro/commit/6027c75))
+* fixing travis notifications ([#2](https://github.com/test-kitchen/kitchen-vro/pull/2)) ([c76470e](https://github.com/test-kitchen/kitchen-vro/commit/c76470e))
+* Bump Rubocop to resolve CVE ([#6](https://github.com/test-kitchen/kitchen-vro/pull/6)) ([07665c6](https://github.com/test-kitchen/kitchen-vro/commit/07665c6))
+* Update kitchen-vro.gemspec ([1b5439b](https://github.com/test-kitchen/kitchen-vro/commit/1b5439b))
+
+* chore(deps): update dependency webmock to v3 ([#11](https://github.com/test-kitchen/kitchen-vro/pull/11)) ([8f3b368](https://github.com/test-kitchen/kitchen-vro/commit/8f3b368))
+* Fix gemspec dependencies test-kitchen logic ([#14](https://github.com/test-kitchen/kitchen-vro/pull/14)) ([011d339](https://github.com/test-kitchen/kitchen-vro/commit/011d339))
+* chore(deps): update google-github-actions/release-please-action action to v4 ([#13](https://github.com/test-kitchen/kitchen-vro/pull/13)) ([49aa642](https://github.com/test-kitchen/kitchen-vro/commit/49aa642))
+
+## 1.0.0 (2015-08-25)
+
+* empty repo ([604d029](https://github.com/test-kitchen/kitchen-vro/commit/604d029))
+* Initial release of kitchen-vro ([#1](https://github.com/test-kitchen/kitchen-vro/pull/1)) ([45f2291](https://github.com/test-kitchen/kitchen-vro/commit/45f2291))


### PR DESCRIPTION
Backfills the changelog so every released version records all of its changes.

## What changed

- **Missing entries added.** These changelogs were generated by release-please, which only writes `feat:`, `fix:` and breaking changes. Everything typed `chore:`, `ci:`, `docs:`, `test:` or `refactor:` was silently dropped. Older versions predate conventional commits entirely and were never written up at all.
- **Entries use the PR title** where a change landed via a pull request, and link both the PR and the commit.
- **Unpublished versions removed.** Versions tagged in git but never published to RubyGems are no longer listed as releases. Their entries roll forward into the version that actually shipped them, so no change record is lost.
- Backfilled entries are grouped under `### Other Changes` where a section already used release-please headings, so they don't read as bug fixes.

RubyGems is treated as the source of truth for whether a release happened.

Nothing outside the changelog is touched, and the commit is a `chore:` so it won't trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
