### PR TITLE
docs: document every method with YARD and add doc rake tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+doc/
+.yardoc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,11 @@
+--markup markdown
+--output-dir doc
+--readme README.md
+--title "kitchen-vro"
+--protected
+--private
+lib/**/*.rb
+-
+CHANGELOG.md
+CONTRIBUTING.md
+LICENSE.txt

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,10 @@ group :test do
   gem "webmock",   "~> 3.0"
 end
 
+group :docs do
+  gem "yard"
+end
+
 group :cookstyle do
   gem "cookstyle"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -14,3 +14,21 @@ end
 RSpec::Core::RakeTask.new(:test)
 
 task default: %i{test style}
+
+begin
+  require "yard"
+
+  # Options and the file list live in .yardopts so that a bare `yard` from the
+  # command line produces exactly what `rake doc` does.
+  YARD::Rake::YardocTask.new(:doc)
+
+  desc "List anything in lib/ that is still undocumented"
+  task :doc_coverage do
+    sh "yard stats --list-undoc"
+  end
+rescue LoadError
+  desc "Generate YARD documentation (not installed)"
+  task :doc do
+    abort "YARD is not installed. Run: bundle install"
+  end
+end

--- a/lib/kitchen/driver/version.rb
+++ b/lib/kitchen/driver/version.rb
@@ -16,8 +16,11 @@
 # limitations under the License.
 #
 
+# Test Kitchen's top-level namespace.
 module Kitchen
+  # Test Kitchen's driver plugins.
   module Driver
+    # The version of the kitchen-vro gem.
     VRO_VERSION = "1.2.3".freeze
   end
 end

--- a/lib/kitchen/driver/vro.rb
+++ b/lib/kitchen/driver/vro.rb
@@ -21,8 +21,28 @@ require "vcoworkflows"
 require_relative "version"
 
 module Kitchen
+  # Test Kitchen's driver plugins.
   module Driver
+    # Test Kitchen driver for VMware vRealize Orchestrator (vRO).
+    #
+    # This driver does not build a machine itself. It runs two vRO workflows
+    # you supply -- one to create a server and one to destroy it -- and treats
+    # their output parameters as the machine's identity.
+    #
+    # The create workflow must return two output parameters, +server_id+ and
+    # +ip_address+, both non-empty. +server_id+ is stored in instance state
+    # and handed back to the destroy workflow, and +ip_address+ becomes the
+    # address the transport connects to. A workflow that completes without
+    # those two fails the +create+, since there would be nothing to connect to
+    # and nothing to tear down later.
+    #
+    # @see https://www.vmware.com/products/vrealize-orchestrator.html vRealize Orchestrator
     class Vro < Kitchen::Driver::Base
+      # @!attribute [rw] workflow_name
+      #   @return [String] name of the workflow currently being run
+      # @!attribute [rw] workflow_id
+      #   @return [String, nil] id of the workflow currently being run, used
+      #     to disambiguate when several workflows share a name
       attr_accessor :workflow_name, :workflow_id
 
       kitchen_driver_api_version 2
@@ -41,10 +61,19 @@ module Kitchen
       default_config :destroy_workflow_parameters, {}
       default_config :request_timeout, 300
 
+      # @return [String] the driver's display name in `kitchen list`
       def name
         "vRO"
       end
 
+      # Runs the create workflow and waits for the server to be reachable.
+      #
+      # Returns immediately if state already names a server, so a re-run does
+      # not create a second one.
+      #
+      # @param state [Hash] mutable instance state; gains +server_id+ and
+      #   +hostname+
+      # @return [void]
       def create(state)
         return unless state[:server_id].nil?
 
@@ -56,6 +85,10 @@ module Kitchen
         info("Server #{state[:hostname]} (#{state[:server_id]}) ready.")
       end
 
+      # Runs the destroy workflow for the server named in state.
+      #
+      # @param state [Hash] instance state naming the server
+      # @return [void]
       def destroy(state)
         return if state[:server_id].nil?
 
@@ -64,6 +97,9 @@ module Kitchen
         info("Server #{state[:hostname]} (#{state[:server_id]}) destroyed.")
       end
 
+      # Connection settings for the vRO API.
+      #
+      # @return [VcoWorkflows::Config]
       def vro_config
         @vro_config ||= VcoWorkflows::Config.new(
           url: config[:vro_base_url],
@@ -73,6 +109,13 @@ module Kitchen
         )
       end
 
+      # Client for the workflow named by {#workflow_name} and {#workflow_id}.
+      #
+      # Memoized, and reset by {#set_workflow_vars}, so switching from the
+      # create workflow to the destroy workflow builds a fresh client rather
+      # than reusing the previous workflow's.
+      #
+      # @return [VcoWorkflows::Workflow]
       def vro_client
         @vro_client ||= VcoWorkflows::Workflow.new(
           workflow_name,
@@ -81,16 +124,32 @@ module Kitchen
         )
       end
 
+      # @return [Boolean] whether to verify the vRO server's TLS certificate
       def verify_ssl?
         !config[:vro_disable_ssl_verify]
       end
 
+      # Points the driver at a different workflow.
+      #
+      # Clears the memoized client, which is what makes it safe to run the
+      # destroy workflow after the create workflow in the same process.
+      #
+      # @param name [String] workflow name
+      # @param id [String, nil] workflow id, when the name is ambiguous
+      # @return [void]
       def set_workflow_vars(name, id)
         @vro_client    = nil
         @workflow_name = name
         @workflow_id   = id
       end
 
+      # Runs the create workflow and records what it produced.
+      #
+      # @param state [Hash] mutable instance state; gains +server_id+ and
+      #   +hostname+
+      # @return [void]
+      # @raise [RuntimeError] if the workflow did not complete successfully,
+      #   or did not return a usable +server_id+ and +ip_address+
       def execute_create_workflow(state)
         set_workflow_vars(config[:create_workflow_name], config[:create_workflow_id])
         set_workflow_parameters(config[:create_workflow_parameters])
@@ -105,6 +164,11 @@ module Kitchen
         state[:hostname]  = output_parameter_value("ip_address")
       end
 
+      # Runs the destroy workflow, passing it the stored +server_id+.
+      #
+      # @param state [Hash] instance state naming the server
+      # @return [void]
+      # @raise [RuntimeError] if the workflow did not complete successfully
       def execute_destroy_workflow(state)
         set_workflow_vars(config[:destroy_workflow_name], config[:destroy_workflow_id])
         set_workflow_parameters(config[:destroy_workflow_parameters])
@@ -115,6 +179,11 @@ module Kitchen
         raise "The workflow did not complete successfully. Check the vRO UI for more info." unless workflow_successful?
       end
 
+      # Submits the current workflow for execution.
+      #
+      # @return [void]
+      # @raise [RestClient::BadRequest] if vRO rejects the request, after
+      #   logging the response body, which is where vRO puts the reason
       def execute_workflow
         vro_client.execute
       rescue RestClient::BadRequest => e
@@ -125,6 +194,10 @@ module Kitchen
         raise
       end
 
+      # Polls until the running workflow's token is no longer alive.
+      #
+      # @return [void]
+      # @raise [Timeout::Error] if it does not finish within +request_timeout+
       def wait_for_workflow
         wait_time = config[:request_timeout]
         Timeout.timeout(wait_time) do
@@ -139,6 +212,13 @@ module Kitchen
         raise Timeout::Error, "Workflow did not complete in #{wait_time} seconds. Please check the vRO UI for more information."
       end
 
+      # Waits for the transport to accept a connection.
+      #
+      # A server that never becomes reachable is destroyed before the error is
+      # re-raised, so a failed create does not leave a machine behind.
+      #
+      # @param state [Hash] instance state describing how to connect
+      # @return [void]
       def wait_for_server(state)
         instance.transport.connection(state).wait_until_ready
       rescue
@@ -147,24 +227,39 @@ module Kitchen
         raise
       end
 
+      # Sets input parameters on the current workflow.
+      #
+      # @param data [Hash] parameter names to values; names are stringified
+      # @return [void]
       def set_workflow_parameters(data) # rubocop:disable Style/AccessorMethodName
         data.each do |key, value|
           vro_client.parameter(key.to_s, value)
         end
       end
 
+      # Output parameters from the finished workflow run.
+      #
+      # @return [Hash{String => VcoWorkflows::WorkflowParameter}]
       def output_parameters
         @output_parameters ||= vro_client.token.output_parameters
       end
 
+      # @param key [String] output parameter name
+      # @return [String] the parameter's value, stringified
       def output_parameter_value(key)
         output_parameters[key].value.to_s
       end
 
+      # @param key [String] output parameter name
+      # @return [Boolean] true when the parameter is missing or empty
       def output_parameter_empty?(key)
         output_parameter_value(key).nil? || output_parameter_value(key).empty?
       end
 
+      # Checks that the create workflow returned what the driver needs.
+      #
+      # @return [void]
+      # @raise [RuntimeError] if +server_id+ or +ip_address+ is absent or empty
       def validate_create_output_parameters!
         raise "The workflow output did not contain a server_id and ip_address parameter." unless
           output_parameters.key?("server_id") && output_parameters.key?("ip_address")
@@ -173,6 +268,7 @@ module Kitchen
         raise "The ip_address parameter was empty." if output_parameter_empty?("ip_address")
       end
 
+      # @return [Boolean] whether the workflow run reached the "completed" state
       def workflow_successful?
         vro_client.token.state == "completed"
       end


### PR DESCRIPTION
## What

`kitchen-vro` sat at **29% documentation coverage** with no way to generate or measure docs.

- All **18 methods** and **both attributes** documented, plus the driver class, both namespace modules, and `VRO_VERSION` → **100%**.
- `.yardopts` added as the single source of truth.
- `rake doc` and `rake doc_coverage` added; `yard` in a `:docs` bundle group.

## The contract worth writing down

This driver doesn't build a machine — it runs two workflows you supply and treats their output as the machine's identity. That depends on a contract which was enforced in code but stated nowhere:

> The create workflow **must** return non-empty `server_id` and `ip_address` output parameters.

`server_id` is what gets handed back to the destroy workflow; `ip_address` is what the transport connects to. A workflow returning neither leaves nothing to connect to *and* nothing to tear down later — which is why `validate_create_output_parameters!` refuses to continue rather than warning. That's now in the class docstring, where someone writing their first vRO workflow will actually see it.

Also documented: `set_workflow_vars` clears the memoized `@vro_client`, and that is precisely what makes running the destroy workflow after the create workflow in the same process pick up the right workflow instead of reusing the previous one.

## Note on the attributes

`attr_accessor :workflow_name, :workflow_id` declares two attributes with different types, so they use `@!attribute` directives rather than one shared docstring — a single block with two `@return` tags would be invalid YARD.

## Verification

```
$ yard stats --list-undoc
Attributes:      2 (    0 undocumented)
Methods:        18 (    0 undocumented)
 100.00% documented
```

```
$ bundle exec rspec
35 examples, 0 failures

$ bundle exec cookstyle --chefstyle lib
2 files inspected, no offenses detected
```

Comments only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)