### PR TITLE
fix: correct the doubled scheme in the gemspec homepage

### DIFF
--- a/kitchen-vro.gemspec
+++ b/kitchen-vro.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["help@sous-chefs.org"]
   spec.summary       = "A Test Kitchen driver for VMware vRealize Orchestrator (vRO)"
   spec.description   = spec.summary
-  spec.homepage      = "https://https://github.com/test-kitchen/kitchen-vro"
+  spec.homepage      = "https://github.com/test-kitchen/kitchen-vro"
   spec.license       = "Apache-2.0"
 
   spec.files         = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
The homepage carried the scheme twice:

```ruby
spec.homepage      = "https://https://github.com/test-kitchen/kitchen-vro"
```

```ruby
spec.homepage      = "https://github.com/test-kitchen/kitchen-vro"
```

`https://https//...` is what RubyGems renders as the project's Homepage link, so the link on the gem page has been dead. Nothing validates this field — `gem build` accepts it without a murmur — which is why it went unnoticed.

## Verification

- `Gem::Specification.load(...).homepage` returns `https://github.com/test-kitchen/kitchen-vro`
- `gem build` succeeds (kitchen-vro 1.2.3)
- `rake test` — 35 examples, 0 failures
- `cookstyle --chefstyle` — 5 files, no offenses
