### PR TITLE
test: cover configuration, metadata, and the untested workflow branches

### DIFF
--- a/spec/vro_spec.rb
+++ b/spec/vro_spec.rb
@@ -64,6 +64,96 @@ describe Kitchen::Driver::Vro do
     allow(driver).to receive(:instance).and_return(instance)
   end
 
+  describe 'plugin metadata' do
+    it 'is a Test Kitchen driver' do
+      expect(driver).to be_a(Kitchen::Driver::Base)
+    end
+
+    it 'shows up as vRO in kitchen list' do
+      expect(driver.name).to eq('vRO')
+    end
+
+    it 'reports its own gem version to kitchen diagnose' do
+      expect(driver.diagnose_plugin[:version]).to eq(Kitchen::Driver::VRO_VERSION)
+    end
+  end
+
+  describe 'configuration' do
+    it 'verifies TLS by default' do
+      expect(driver[:vro_disable_ssl_verify]).to eq(false)
+    end
+
+    it 'defaults to a 300 second workflow timeout' do
+      expect(driver[:request_timeout]).to eq(300)
+    end
+
+    it 'defaults both workflow ids to nil so the name is used alone' do
+      config.delete(:create_workflow_id)
+      config.delete(:destroy_workflow_id)
+
+      expect(driver[:create_workflow_id]).to be_nil
+      expect(driver[:destroy_workflow_id]).to be_nil
+    end
+
+    it 'defaults both workflow parameter sets to empty' do
+      expect(driver[:create_workflow_parameters]).to eq({})
+      expect(driver[:destroy_workflow_parameters]).to eq({})
+    end
+
+    %i[vro_username vro_password vro_base_url
+       create_workflow_name destroy_workflow_name].each do |key|
+      it "refuses to run without #{key}" do
+        config.delete(key)
+
+        expect { driver.finalize_config!(instance) }
+          .to raise_error(Kitchen::UserError, /#{key}/)
+      end
+    end
+  end
+
+  describe '#set_workflow_vars' do
+    it 'points the driver at the named workflow' do
+      driver.set_workflow_vars('Some Workflow', 'workflow-9')
+
+      expect(driver.workflow_name).to eq('Some Workflow')
+      expect(driver.workflow_id).to eq('workflow-9')
+    end
+
+    it 'discards the memoized client so the next call builds a new one' do
+      first = double('first client')
+      allow(VcoWorkflows::Workflow).to receive(:new).and_return(first)
+      allow(driver).to receive(:vro_config).and_return(double('config'))
+      driver.set_workflow_vars('Create Workflow', 'workflow-1')
+      expect(driver.vro_client).to eq(first)
+
+      second = double('second client')
+      allow(VcoWorkflows::Workflow).to receive(:new).and_return(second)
+      driver.set_workflow_vars('Destroy Workflow', 'workflow-2')
+
+      expect(driver.vro_client).to eq(second)
+    end
+  end
+
+  describe '#workflow_successful?' do
+    let(:vro_client) { double('vro_client') }
+
+    before do
+      allow(driver).to receive(:vro_client).and_return(vro_client)
+    end
+
+    it 'is true when vRO reports the run completed' do
+      allow(vro_client).to receive(:token).and_return(double(state: 'completed'))
+
+      expect(driver.workflow_successful?).to eq(true)
+    end
+
+    it 'is false for any other state' do
+      allow(vro_client).to receive(:token).and_return(double(state: 'failed'))
+
+      expect(driver.workflow_successful?).to eq(false)
+    end
+  end
+
   describe '#create' do
     context 'when a server already exists' do
       let(:state) { { server_id: 'server-12345' } }
@@ -142,11 +232,11 @@ describe Kitchen::Driver::Vro do
 
     context 'when vro_disable_ssl_verify is false' do
       before do
-        config[:vro_disable_ssl_verify] = true
+        config[:vro_disable_ssl_verify] = false
       end
 
       it 'returns true' do
-        expect(driver.verify_ssl?).to eq(false)
+        expect(driver.verify_ssl?).to eq(true)
       end
     end
   end


### PR DESCRIPTION
35 examples for a driver with 18 methods, and one of them was testing the wrong thing.

## The example that could not fail

```ruby
context 'when vro_disable_ssl_verify is false' do
  before do
    config[:vro_disable_ssl_verify] = true   # <- true
  end

  it 'returns true' do
    expect(driver.verify_ssl?).to eq(false)  # <- false
  end
end
```

A copy of the `true` context with the name changed and nothing else. Both branches of `#verify_ssl?` were asserting the same thing, so the `false` path — the one that decides whether the driver validates the vRO server's TLS certificate — had never been executed by a test. Fixed to set `false` and expect `true`.

## What was untested

| area | why it matters |
|---|---|
| `#name` | the string `kitchen list` prints |
| `plugin_version` | `kitchen diagnose` output |
| configuration defaults | `vro_disable_ssl_verify` defaulting to `false` is a security-relevant default and nothing pinned it |
| `required_config` | five settings the driver cannot run without, none of them checked |
| `#set_workflow_vars` | resets the memoized client, which is the only reason running destroy after create in one process works |
| `#workflow_successful?` | neither branch |

The `#set_workflow_vars` test is the one I would keep if I could keep only one: the memoization reset is load bearing and invisible, and a refactor that dropped `@vro_client = nil` would have gone green.

## Verification

- `rake test` — **51 examples, 0 failures** (35 before; 16 new, 1 corrected)
- `cookstyle --chefstyle` — clean; `lib/` is untouched by this PR
