### PR TITLE
fix: require cookstyle/chefstyle so style checks actually run

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,13 +2,13 @@ require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
 begin
-  require "chefstyle"
+  require "cookstyle/chefstyle"
   require "rubocop/rake_task"
   RuboCop::RakeTask.new(:style) do |task|
     task.options += ["--display-cop-names", "--no-color"]
   end
 rescue LoadError
-  puts "chefstyle is not available. (sudo) gem install chefstyle to do style checking."
+  puts "cookstyle is not available. (sudo) gem install cookstyle to do style checking."
 end
 
 RSpec::Core::RakeTask.new(:test)


### PR DESCRIPTION
The Rakefile requires the standalone `chefstyle` gem:

```ruby
begin
  require "chefstyle"
  require "rubocop/rake_task"
  RuboCop::RakeTask.new(:style) { ... }
rescue LoadError
  puts "chefstyle is not available. ..."
end
```

but `chefstyle` appears in neither the Gemfile nor the gemspec — the `:cookstyle` group declares `cookstyle` and nothing else. The `require` therefore falls into the `rescue LoadError` branch, the `:style` task is never defined, and style checking silently does not happen.

Chefstyle was absorbed into Cookstyle, which ships the rule set as `cookstyle/chefstyle` (it sets `CHEFSTYLE_CONFIG = true` and then loads cookstyle). Requiring that path uses the gem that is actually installed. kitchen-pester's Rakefile already does exactly this.

Expect `rake style` to start reporting offenses that were previously going unchecked.